### PR TITLE
Make netCDF4 optional on Emscripten/WASM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dependencies = ['pycdfpp>=0.6.0', 'netCDF4']
+dependencies = ['pycdfpp>=0.6.0', 'netCDF4; sys_platform != "emscripten"']
 [project.urls]
 homepage = "https://github.com/SciQLop/PyISTP"
 repository = "https://github.com/SciQLop/PyISTP"


### PR DESCRIPTION
`netCDF4` is a compiled extension with no Pyodide wheel, so the unconditional `'netCDF4'` dependency (added in 0.8.0) makes PyISTP — and anything that depends on it, like Speasy — fail to install under WASM/Pyodide (`micropip` errors with *Can't find a pure Python 3 wheel for 'netcdf4'*).

Mark it `netCDF4; sys_platform != "emscripten"` so micropip skips it on WASM. The netCDF driver is already imported lazily (only inside `_driver_factory`, when a netCDF/HDF file is actually read), so `import pyistp` keeps working without netCDF4; CDF support via `pycdfpp` is unaffected.

Needs a release (0.8.1) for Speasy's WASM CI to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)